### PR TITLE
 introduced the request-verification public function to the KYCrypt smart contract, enabling users to submit a KYC verification request by providing their KYC data on-chain.

### DIFF
--- a/contracts/KYCKey.clar
+++ b/contracts/KYCKey.clar
@@ -1,15 +1,121 @@
 
 ;; KYCKey
-;; <add a description here>
+;; KYCrypt - Decentralized KYC Verification Platform
+;; Manages KYC verification status for addresses
+
+;; title: verify
+;; version:
+;; summary:
+;; description:
+;; Error codes
+(define-constant ERR_UNAUTHORIZED u100)
+(define-constant ERR_ALREADY_VERIFIED u101)
+(define-constant ERR_NOT_VERIFIED u102)
+(define-constant ERR_INVALID_STATUS u103)
+(define-constant ERR_INVALID_INPUT u104)
+(define-constant ERR_INVALID_NEW_OWNER u105)
+
+;; traits
+;;
+;; Data variables
+(define-data-var contract-owner principal tx-sender)
+
+;; token definitions
+;;
+;; Verification status map
+(define-map verified-addresses 
+    principal 
+    {
+        status: uint,  ;; 0: not verified, 1: pending, 2: verified, 3: rejected
+        timestamp: uint,
+        kyc-data: (string-utf8 500),
+        verifier: principal
+    }
+)
 
 ;; constants
 ;;
+;; Read-only functions
+(define-read-only (get-verification-status (address principal))
+    (default-to 
+        {
+            status: u0, 
+            timestamp: u0, 
+            kyc-data: u"", 
+            verifier: tx-sender
+        }
+        (map-get? verified-addresses address)
+    )
+)
 
-;; data maps and vars
+;; data vars
 ;;
+(define-read-only (is-contract-owner (address principal))
+    (is-eq address (var-get contract-owner))
+)
 
-;; private functions
+;; data maps
 ;;
+;; Helper function for input validation
+(define-private (is-valid-principal (address principal))
+    (and 
+        (not (is-eq address (as-contract tx-sender)))  ;; Prevent contract self-interaction
+        (not (is-eq address tx-sender))  ;; Prevent sender from manipulating other addresses
+    )
+)
 
 ;; public functions
 ;;
+;; Helper function for KYC data validation
+(define-private (is-valid-kyc-data (data (string-utf8 500)))
+    (and 
+        (> (len data) u0)  ;; Ensure non-empty
+        (<= (len data) u500)  ;; Ensure within max length
+    )
+)
+
+;; read only functions
+;;
+;; Helper function for status validation
+(define-private (validate-status-change 
+    (current-status uint) 
+    (allowed-statuses (list 10 uint)))
+    (is-some (index-of allowed-statuses current-status))
+)
+
+;; Private function to validate input address
+(define-private (validate-input-address (address principal))
+    (ok (asserts! (is-valid-principal address) (err ERR_INVALID_INPUT)))
+)
+
+
+;; private functions
+;;
+;; Helper function for additional new owner validation
+(define-private (is-valid-new-owner (new-owner principal))
+    (and
+        (is-valid-principal new-owner)  ;; Use existing principal validation
+        (not (is-eq new-owner (var-get contract-owner)))  ;; Prevent setting same owner
+    )
+)
+
+;; Public functions
+(define-public (request-verification (kyc-data (string-utf8 500)))
+    (begin
+        ;; Validate KYC data input
+        (asserts! (is-valid-kyc-data kyc-data) (err ERR_INVALID_INPUT))
+        (let 
+            ((current-status (get status (get-verification-status tx-sender))))
+            (asserts! (is-eq current-status u0) (err ERR_ALREADY_VERIFIED))
+            (map-set verified-addresses tx-sender
+                {
+                    status: u1,
+                    timestamp: stacks-block-height,
+                    kyc-data: kyc-data,
+                    verifier: tx-sender
+                }
+            )
+            (ok true)
+        )
+    )
+)


### PR DESCRIPTION
---

# PR: Implement `request-verification` Function for KYCrypt Contract

## Overview

This PR introduces the `request-verification` public function to the **KYCrypt** smart contract, enabling users to submit a KYC verification request by providing their KYC data on-chain.

---

## Functionality

* **Function Name:** `request-verification`
* **Input:** `kyc-data` (string-utf8 500) — User-supplied KYC data string (e.g., JSON or other structured info).
* **Output:** `(response bool)` — Returns `true` upon successful submission.

---

## Details

* Validates that the KYC data is non-empty and does not exceed 500 UTF-8 characters.
* Checks the caller’s current verification status and ensures the status is `0` (Not Verified). If the caller is already verified or has a pending request, it throws an `ERR_ALREADY_VERIFIED` error.
* Records the verification request in the `verified-addresses` map:

  * Sets status to `1` (Pending).
  * Stores the KYC data submitted.
  * Sets the timestamp to the current block height.
  * Sets the verifier field to the caller’s address (`tx-sender`).
* Returns `true` on success.

---

## Error Handling

| Error Code                   | Condition                                            |
| ---------------------------- | ---------------------------------------------------- |
| `ERR_INVALID_INPUT (104)`    | KYC data is empty or exceeds 500 characters.         |
| `ERR_ALREADY_VERIFIED (101)` | The caller already has a pending or verified status. |

---

## Code Snippet

```lisp
(define-public (request-verification (kyc-data (string-utf8 500)))
  (begin
    ;; Validate KYC data input
    (asserts! (is-valid-kyc-data kyc-data) (err ERR_INVALID_INPUT))
    (let 
      ((current-status (get status (get-verification-status tx-sender))))
      ;; Ensure status is 0 (Not Verified)
      (asserts! (is-eq current-status u0) (err ERR_ALREADY_VERIFIED))
      ;; Set status to 1 (Pending) with KYC data and timestamp
      (map-set verified-addresses tx-sender
        {
          status: u1,
          timestamp: stacks-block-height,
          kyc-data: kyc-data,
          verifier: tx-sender
        }
      )
      (ok true)
    )
  )
)
```

---