### PR TITLE
added critical management functions for the KYCrypt decentralized KYC platform,

### DIFF
--- a/contracts/KYCKey.clar
+++ b/contracts/KYCKey.clar
@@ -119,3 +119,122 @@
         )
     )
 )
+
+
+
+(define-public (verify-address (address principal))
+    (begin
+        ;; Validate input address
+        (try! (validate-input-address address))
+
+        ;; Ensure only contract owner can verify
+        (try! (validate-owner-only))
+
+        ;; Get current verification status
+        (let ((current-status (get status (get-verification-status address))))
+            ;; Validate status for verification
+            (asserts! (validate-status-change current-status (list u1)) (err ERR_INVALID_STATUS))
+            (map-set verified-addresses address
+                {
+                    status: u2,
+                    timestamp: stacks-block-height,
+                    kyc-data: (get kyc-data (get-verification-status address)),
+                    verifier: tx-sender
+                }
+            )
+            (ok true)
+        )
+    )
+)
+
+(define-public (reject-verification (address principal))
+    (begin
+        ;; Validate input address
+        (try! (validate-input-address address))
+
+        ;; Ensure only contract owner can reject
+        (try! (validate-owner-only))
+
+        ;; Get current verification status
+        (let ((current-status (get status (get-verification-status address))))
+            ;; Validate status for rejection
+            (asserts! (validate-status-change current-status (list u1)) (err ERR_INVALID_STATUS))
+            (map-set verified-addresses address
+                {
+                    status: u3,
+                    timestamp: stacks-block-height,
+                    kyc-data: (get kyc-data (get-verification-status address)),
+                    verifier: tx-sender
+                }
+            )
+            (ok true)
+        )
+    )
+)
+
+
+
+;; Private function to validate owner-only operations
+(define-private (validate-owner-only)
+    (ok (asserts! (is-contract-owner tx-sender) (err ERR_UNAUTHORIZED)))
+)
+
+(define-public (transfer-ownership (new-owner principal))
+    (begin
+        ;; Validate new owner address with additional checks
+        (asserts! (is-valid-new-owner new-owner) (err ERR_INVALID_NEW_OWNER))
+
+        ;; Ensure only current owner can transfer
+        (try! (validate-owner-only))
+
+        ;; Update contract owner
+        (var-set contract-owner new-owner)
+
+        ;; Optional: Initialize new owner's verification status
+        (map-set verified-addresses new-owner
+            {
+                status: u0,
+                timestamp: stacks-block-height,
+                kyc-data: u"",
+                verifier: tx-sender
+            }
+        )
+
+        (ok true)
+    )
+)
+
+(define-public (revoke-verification (address principal))
+    (begin
+        ;; Validate input address
+        (try! (validate-input-address address))
+
+        ;; Ensure only contract owner can revoke
+        (try! (validate-owner-only))
+
+        ;; Get current verification status
+        (let ((current-status (get status (get-verification-status address))))
+            ;; Validate status for revocation
+            (asserts! (validate-status-change current-status (list u1 u2)) (err ERR_INVALID_STATUS))
+            (map-set verified-addresses address
+                {
+                    status: u0,
+                    timestamp: stacks-block-height,
+                    kyc-data: (get kyc-data (get-verification-status address)),
+                    verifier: tx-sender
+                }
+            )
+            (ok true)
+        )
+    )
+)
+
+
+;; Initialize the contract with deployer's address
+(map-set verified-addresses tx-sender
+    {
+        status: u0,
+        timestamp: stacks-block-height,
+        kyc-data: u"",
+        verifier: tx-sender
+    })


### PR DESCRIPTION


# PR: Add Verification Management and Ownership Transfer Functions to KYCrypt Contract

## Overview

This PR adds critical management functions for the **KYCrypt** decentralized KYC platform, enabling the contract owner to:

* Verify user-submitted KYC requests.
* Reject KYC requests.
* Revoke verifications.
* Transfer contract ownership securely.

These functions enforce access control, state validation, and update the verification status accordingly.

---

## Functionality

### 1. `verify-address(address: principal)`

* Only callable by the contract owner.
* Validates the input address.
* Checks the address has a pending verification request (`status == 1`).
* Updates the status to `2` (Verified), updates timestamp and verifier info.

### 2. `reject-verification(address: principal)`

* Only callable by the contract owner.
* Validates the input address.
* Checks the address has a pending verification request (`status == 1`).
* Updates the status to `3` (Rejected), updates timestamp and verifier info.

### 3. `revoke-verification(address: principal)`

* Only callable by the contract owner.
* Validates the input address.
* Checks the address is either pending (`1`) or verified (`2`).
* Resets status back to `0` (Not Verified), updates timestamp and verifier info.

### 4. `transfer-ownership(new-owner: principal)`

* Only callable by the current contract owner.
* Validates the new owner’s principal (must be different and valid).
* Updates the contract owner.
* Initializes the new owner’s verification status to `0` (Not Verified).

---

## Access Control

* Uses the private helper function `validate-owner-only` to restrict sensitive operations exclusively to the contract owner.
* `validate-owner-only` asserts that `tx-sender` equals the stored `contract-owner`.

---

## Validation

* All input principals are validated via `validate-input-address` or `is-valid-new-owner`.
* Verification status transitions are strictly checked with `validate-status-change` to prevent invalid state changes.

---

## Error Handling

| Error Code                    | Condition                                       |
| ----------------------------- | ----------------------------------------------- |
| `ERR_UNAUTHORIZED (100)`      | Action attempted by non-owner.                  |
| `ERR_INVALID_STATUS (103)`    | Status is not valid for requested operation.    |
| `ERR_INVALID_INPUT (104)`     | Invalid input principal address.                |
| `ERR_INVALID_NEW_OWNER (105)` | New owner principal invalid or same as current. |

---

## Code Highlights

```lisp
;; Verifies an address with pending status (1) and sets status to verified (2)
(define-public (verify-address (address principal))
  (begin
    (try! (validate-input-address address))
    (try! (validate-owner-only))
    (let ((current-status (get status (get-verification-status address))))
      (asserts! (validate-status-change current-status (list u1)) (err ERR_INVALID_STATUS))
      (map-set verified-addresses address
        {
          status: u2,
          timestamp: stacks-block-height,
          kyc-data: (get kyc-data (get-verification-status address)),
          verifier: tx-sender
        })
      (ok true))))
```

```lisp
;; Rejects an address with pending status (1) and sets status to rejected (3)
(define-public (reject-verification (address principal))
  (begin
    (try! (validate-input-address address))
    (try! (validate-owner-only))
    (let ((current-status (get status (get-verification-status address))))
      (asserts! (validate-status-change current-status (list u1)) (err ERR_INVALID_STATUS))
      (map-set verified-addresses address
        {
          status: u3,
          timestamp: stacks-block-height,
          kyc-data: (get kyc-data (get-verification-status address)),
          verifier: tx-sender
        })
      (ok true))))
```

```lisp
;; Transfers contract ownership to new valid principal
(define-public (transfer-ownership (new-owner principal))
  (begin
    (asserts! (is-valid-new-owner new-owner) (err ERR_INVALID_NEW_OWNER))
    (try! (validate-owner-only))
    (var-set contract-owner new-owner)
    (map-set verified-addresses new-owner
      {
        status: u0,
        timestamp: stacks-block-height,
        kyc-data: u"",
        verifier: tx-sender
      })
    (ok true)))
```

```lisp
;; Revokes verification status, resetting it to not verified (0)
(define-public (revoke-verification (address principal))
  (begin
    (try! (validate-input-address address))
    (try! (validate-owner-only))
    (let ((current-status (get status (get-verification-status address))))
      (asserts! (validate-status-change current-status (list u1 u2)) (err ERR_INVALID_STATUS))
      (map-set verified-addresses address
        {
          status: u0,
          timestamp: stacks-block-height,
          kyc-data: (get kyc-data (get-verification-status address)),
          verifier: tx-sender
        })
      (ok true))))
```

---
